### PR TITLE
Use upstream default for DB path

### DIFF
--- a/root/usr/bin/tangd-entrypoint
+++ b/root/usr/bin/tangd-entrypoint
@@ -3,6 +3,6 @@ set -e
 
 TANG_LISTEN_PORT=${TANG_LISTEN_PORT:-80}
 
-mkdir -p /var/db/tang /var/cache/tang
+mkdir -p /var/db/tang
 
-socat tcp-l:$TANG_LISTEN_PORT,reuseaddr,fork exec:"/usr/libexec/tangd /var/cache/tang"
+socat tcp-l:$TANG_LISTEN_PORT,reuseaddr,fork exec:"/usr/libexec/tangd /var/db/tang"


### PR DESCRIPTION
Following the principle of least surpise, using a path matching the upstream docs[1] is likely to cause least confusion. Given not many people are using this container, it seems OK to make this breaking change.

[1] https://github.com/latchset/tang/blob/b088c37a65a03c31223e64a5fcd47fb458244979/doc/tang.8.adoc

Fixes #2.